### PR TITLE
Add free domain setup references to README.md and home-lab.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,12 @@ curl http://localhost:3001/api/health
 
 ### **🔑 Domain Configuration**
 > **CRITICAL**: This project uses `gameapp.games` as an example domain. For your own deployment:
-> 1. Replace all instances of `gameapp.games` with your domain
-> 2. Configure Cloudflare DNS for your domain
-> 3. Update ingress configurations accordingly
+> 1. **Get a domain** (free options available for learning)
+> 2. Replace all instances of `gameapp.games` with your domain
+> 3. Configure Cloudflare DNS for your domain
+> 4. Update ingress configurations accordingly
 > 
-> **📝 See**: [Domain Replacement Guide](docs/domain-replacement-guide.md)
+> **📝 See**: [Domain Replacement Guide](docs/domain-replacement-guide.md) | [Free Domain Setup](docs/07-global.md#step-3a-prerequisites---get-a-domain)
 
 ### **💻 System Requirements**
 - **RAM**: 4GB+ available for Kubernetes cluster

--- a/home-lab.md
+++ b/home-lab.md
@@ -8,6 +8,8 @@
 
 **🔗 See: [Domain Replacement Guide](docs/domain-replacement-guide.md)** for the complete list of files to update.
 
+**🆓 Need a free domain? See: [Free Domain Setup](docs/07-global.md#step-3a-prerequisites---get-a-domain)** (Freenom, Duck DNS options)
+
 **🌐 For Cloudflare Tunnel setup, see: [Cloudflare Tunnel Setup Guide](docs/cloudflare-tunnel-setup-guide.md)**
 
 **❌ If you don't replace the domain, the card flipping functionality will break and you'll get stuck at Milestone 1.**


### PR DESCRIPTION
- Added direct links to free domain setup instructions (Freenom, Duck DNS)
- Improved discoverability for beginners in main entry points
- Added step-by-step guidance for domain acquisition
- Enhanced user experience with clear service names and direct links